### PR TITLE
Fix Radius Crash

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -17,7 +17,7 @@ repositories {
     /**
      * NBT API
      */
-    maven("https://repo.codemc.org/repository/maven-public/")
+    maven("https://repo.codemc.io/repository/maven-public/")
 
     /**
      * Paper Team

--- a/src/main/java/com/badbones69/crazyenvoys/api/CrazyManager.java
+++ b/src/main/java/com/badbones69/crazyenvoys/api/CrazyManager.java
@@ -532,6 +532,11 @@ public class CrazyManager {
             maxSpawns = envoySettings.isRandomLocationsEnabled() ? envoySettings.getMaxCrates() : locationSettings.getActiveLocations().size();
         }
 
+        if (maxSpawns > (Math.pow(envoySettings.getMaxRadius(), 2) - Math.pow((envoySettings.getMinRadius() * 2 + 1), 2))) {
+            maxSpawns = (int) (Math.pow(envoySettings.getMaxRadius(), 2) - Math.pow((envoySettings.getMinRadius() * 2 + 1), 2));
+            plugin.getLogger().warning("Crate spawn amount is larger than the area that was provided. Spawning " + maxSpawns + " crates instead.");
+        }
+
         if (envoySettings.isRandomLocationsEnabled()) {
             if (!testCenter()) return new ArrayList<>();
 

--- a/src/main/java/com/badbones69/crazyenvoys/api/CrazyManager.java
+++ b/src/main/java/com/badbones69/crazyenvoys/api/CrazyManager.java
@@ -532,8 +532,8 @@ public class CrazyManager {
             maxSpawns = envoySettings.isRandomLocationsEnabled() ? envoySettings.getMaxCrates() : locationSettings.getActiveLocations().size();
         }
 
-        if (maxSpawns > (Math.pow(envoySettings.getMaxRadius(), 2) - Math.pow((envoySettings.getMinRadius() * 2 + 1), 2))) {
-            maxSpawns = (int) (Math.pow(envoySettings.getMaxRadius(), 2) - Math.pow((envoySettings.getMinRadius() * 2 + 1), 2));
+        if (maxSpawns > (Math.pow(envoySettings.getMaxRadius() * 2, 2) - Math.pow((envoySettings.getMinRadius() * 2 + 1), 2))) {
+            maxSpawns = (int) (Math.pow(envoySettings.getMaxRadius() * 2, 2) - Math.pow((envoySettings.getMinRadius() * 2 + 1), 2));
             plugin.getLogger().warning("Crate spawn amount is larger than the area that was provided. Spawning " + maxSpawns + " crates instead.");
         }
 
@@ -545,7 +545,7 @@ public class CrazyManager {
             while (locationSettings.getDropLocations().size() < maxSpawns) {
                 int maxRadius = envoySettings.getMaxRadius();
                 Location location = center.clone();
-                location.add(-(maxRadius / 2) + random.nextInt(maxRadius), 0, -(maxRadius / 2) + random.nextInt(maxRadius));
+                location.add(-(maxRadius) + random.nextInt(maxRadius * 2), 0, -(maxRadius) + random.nextInt(maxRadius * 2));
                 location = location.getWorld().getHighestBlockAt(location).getLocation();
 
                 if (!location.getChunk().isLoaded() && !location.getChunk().load()) continue;


### PR DESCRIPTION
Fixed crashes caused by the radius of envoys by:
- Changing Max-Radius so that it is actually the radius instead of the diameter.
- Adding a check to make sure that there is enough room for all crates to spawn.

Change the NBT-API link to the new one.