### PR TITLE
Fix Stuck Thread

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -31,7 +31,7 @@ holographic_displays = { module = "me.filoghost.holographicdisplays:holographicd
 decent_holograms = { module = "com.github.decentsoftware-eu:decentholograms", version = "2.7.8" }
 
 cmi_api = { module = "com.Zrips.CMI:CMI-API", version = "9.2.6.1" }
-cmi_lib = { module = "net.Zrips.CMILib:CMI-Lib", version = "1.2.4.1" }
+cmi_lib = { module = "net.Zrips.CMILib:CMI-Lib", version = "1.2.4.5" }
 
 # Placeholders
 placeholder_api = { module = "me.clip:placeholderapi", version = "2.11.2" }

--- a/platforms/paper/src/main/java/com/badbones69/crazyenvoys/api/CrazyManager.java
+++ b/platforms/paper/src/main/java/com/badbones69/crazyenvoys/api/CrazyManager.java
@@ -549,7 +549,7 @@ public class CrazyManager {
 
                 if (!location.getChunk().isLoaded() && !location.getChunk().load()) continue;
 
-                if (location.getBlockY() <= 0 ||
+                if (location.getBlockY() <= location.getWorld().getMinHeight() ||
                         minimumRadiusBlocks.contains(location.getBlock()) || minimumRadiusBlocks.contains(location.clone().add(0, 1, 0).getBlock()) ||
                         locationSettings.getDropLocations().contains(location.getBlock()) || locationSettings.getDropLocations().contains(location.clone().add(0, 1, 0).getBlock()) ||
                         blacklistedBlocks.contains(location.getBlock().getType())) continue;


### PR DESCRIPTION
- Bump CMI-Lib version.
- Fix the problem that occurs when the y level of the highest blocks in the spawn area are all below y=1.

Solves <https://github.com/Crazy-Crew/CrazyEnvoys/issues/87>