### PR TITLE
Fix Non-Random Spawn Locations

### DIFF
--- a/platforms/paper/src/main/java/com/badbones69/crazyenvoys/api/CrazyManager.java
+++ b/platforms/paper/src/main/java/com/badbones69/crazyenvoys/api/CrazyManager.java
@@ -563,7 +563,7 @@ public class CrazyManager {
             Files.DATA.getFile().set("Locations.Spawned", getBlockList(locationSettings.getDropLocations()));
             Files.DATA.saveFile();
         } else {
-            if (!envoySettings.isMaxCrateEnabled()) {
+            if (envoySettings.isMaxCrateEnabled() || envoySettings.isRandomAmount()) {
                 if (locationSettings.getSpawnLocations().size() <= maxSpawns) {
                     locationSettings.addAllDropLocations(locationSettings.getSpawnLocations());
                 } else {

--- a/platforms/paper/src/main/resources/config.yml
+++ b/platforms/paper/src/main/resources/config.yml
@@ -9,8 +9,8 @@ Settings:
   Falling-Block: 'BEACON' #The block that will be falling.
   Fall-Height: 15 #How high the falling blocks spawn.
   # This option should ONLY be used if Random-Locations is false.
-  Max-Crate-Toggle: false #If true then only a specified amount of crates will spawn and if false then all crates will spawn.
-  Random-Amount: false # Selects a random number of crates between the Min-Crates and Max-Crates value (if true)
+  Max-Crate-Toggle: false #If true then Max-Crates amount of crates will spawn and if false and using set spawn locations, then all crates will spawn.
+  Random-Amount: false #If true, selects a random number of crates between the Min-Crates and Max-Crates values. Max-Crate-Toggle has to be false for this to work.
   Min-Crates: 7 #The min amount of crates that will spawn.
   Max-Crates: 20 #The max amount of crates that will spawn.
   Random-Locations: false #If true you will need to make sure to set the center location.


### PR DESCRIPTION
- Change it back over to how it was before but added random amount of spawn locations in with it as well. 
     This will allow people to pick a set amount, max amount or random amount of crates with non-random spawn locations.
     This should also fix the no-spawn locations problem that occurred when Max-Crate-Toggle, Random-Amount and Random- 
    Locations were all set to false. (Goes back to ignoring the value of the spawned crates before having spawned them `locationSettings.getActiveLocations().size()`)
- Changed the comments a bit to better state what each option does.

If I am correct about what it should do now, then this should work.
Haven't found any problems while spamming envoys as well yet.