### PR TITLE
Fix Decent Holograms error due to non-allowed chars

### DIFF
--- a/paper/src/main/java/com/badbones69/crazyenvoys/util/MiscUtils.java
+++ b/paper/src/main/java/com/badbones69/crazyenvoys/util/MiscUtils.java
@@ -5,6 +5,6 @@ import org.bukkit.Location;
 public class MiscUtils {
 
     public static String toString(final Location location) {
-        return location.getWorld().getName() + ":" + location.getX() + ":" + location.getY() + ":" + location.getZ();
+        return location.getWorld().getName() + "_" + location.getBlockX() + "_" + location.getBlockY() + "_" + location.getBlockZ();
     }
 }


### PR DESCRIPTION
This PR changes the unique ID bound to holograms to not use ':' and '.' which was the primary reason the plugin didn't work with DecentHolograms.