### PR TITLE
Removed ignoreCancelled due to unwanted side-effects

### DIFF
--- a/paper/src/main/java/com/badbones69/crazyenvoys/listeners/FlareClickListener.java
+++ b/paper/src/main/java/com/badbones69/crazyenvoys/listeners/FlareClickListener.java
@@ -28,7 +28,7 @@ public class FlareClickListener implements Listener {
 
     private @NotNull final FlareSettings flareSettings = this.plugin.getFlareSettings();
 
-    @EventHandler(ignoreCancelled = true)
+    @EventHandler
     public void onFlareInteract(PlayerInteractEvent event) {
         Player player = event.getPlayer();
 


### PR DESCRIPTION
This solves default flares not working with action RIGHT_CLICK_AIR due to their already cancelled nature.