### PR TITLE
Improved ignore functionality

### DIFF
--- a/paper/src/main/java/com/badbones69/crazyenvoys/api/CrazyManager.java
+++ b/paper/src/main/java/com/badbones69/crazyenvoys/api/CrazyManager.java
@@ -361,7 +361,7 @@ public class CrazyManager {
                         if (check.compareTo(cal) == 0) {
                             HashMap<String, String> placeholder = new HashMap<>();
                             placeholder.put("{time}", getNextEnvoyTime());
-                            Messages.warning.broadcastMessage(false, placeholder);
+                            Messages.warning.broadcastMessage(config.getProperty(ConfigKeys.envoys_ignore_behaviour_warning), placeholder);
                         }
                     }
 
@@ -374,7 +374,7 @@ public class CrazyManager {
                             if (online < config.getProperty(ConfigKeys.envoys_minimum_players_amount)) {
                                 HashMap<String, String> placeholder = new HashMap<>();
                                 placeholder.put("{amount}", online + "");
-                                Messages.not_enough_players.broadcastMessage(false, placeholder);
+                                Messages.not_enough_players.broadcastMessage(config.getProperty(ConfigKeys.envoys_ignore_behaviour_not_enough_players), placeholder);
 
                                 setNextEnvoy(getEnvoyCooldown());
                                 resetWarnings();
@@ -707,7 +707,7 @@ public class CrazyManager {
             resetWarnings();
             EnvoyEndEvent event = new EnvoyEndEvent(EnvoyEndReason.NO_LOCATIONS_FOUND);
             this.pluginManager.callEvent(event);
-            Messages.no_spawn_locations_found.broadcastMessage(false);
+            Messages.no_spawn_locations_found.broadcastMessage(this.config.getProperty(ConfigKeys.envoys_ignore_behaviour_no_spawn_locations_found));
             return false;
         }
 
@@ -727,7 +727,7 @@ public class CrazyManager {
         int max = dropLocations.size();
         HashMap<String, String> placeholder = new HashMap<>();
         placeholder.put("{amount}", String.valueOf(max));
-        Messages.started.broadcastMessage(false, placeholder);
+        Messages.started.broadcastMessage(this.config.getProperty(ConfigKeys.envoys_ignore_behaviour_started), placeholder);
 
         if (this.config.getProperty(ConfigKeys.envoys_grace_period_toggle)) {
             this.countdownTimer = new CountdownTimer(this.plugin, this.config.getProperty(ConfigKeys.envoys_grace_period_timer));
@@ -783,7 +783,7 @@ public class CrazyManager {
             public void run() {
                 EnvoyEndEvent event = new EnvoyEndEvent(EnvoyEndReason.OUT_OF_TIME);
                 plugin.getServer().getPluginManager().callEvent(event);
-                Messages.ended.broadcastMessage(false);
+                Messages.ended.broadcastMessage(config.getProperty(ConfigKeys.envoys_ignore_behaviour_ended));
                 endEnvoyEvent();
             }
         }.runDelayed(getTimeSeconds(this.config.getProperty(ConfigKeys.envoys_run_time)) * 20L);

--- a/paper/src/main/java/com/badbones69/crazyenvoys/api/enums/Messages.java
+++ b/paper/src/main/java/com/badbones69/crazyenvoys/api/enums/Messages.java
@@ -101,6 +101,7 @@ public enum Messages {
 
     private @NotNull final CrazyEnvoys plugin = CrazyEnvoys.get();
     private @NotNull final SettingsManager messages = ConfigManager.getMessages();
+    private @NotNull final SettingsManager config = ConfigManager.getConfig();
     private @NotNull final CrazyManager crazyManager = this.plugin.getCrazyManager();
 
     private final FusionPaper fusion = this.plugin.getFusion();

--- a/paper/src/main/java/com/badbones69/crazyenvoys/config/types/ConfigKeys.java
+++ b/paper/src/main/java/com/badbones69/crazyenvoys/config/types/ConfigKeys.java
@@ -218,4 +218,12 @@ public class ConfigKeys implements SettingsHolder {
             "3s",
             "1s"
     ));
+
+    @Comment("Pick which messages are influenced by the ignore functionality (/envoy ignore)")
+    public static final Property<Boolean> envoys_ignore_behaviour_ended = newProperty("envoys.ignore-behaviour.ended", false);
+    public static final Property<Boolean> envoys_ignore_behaviour_warning = newProperty("envoys.ignore-behaviour.warning", false);
+    public static final Property<Boolean> envoys_ignore_behaviour_not_enough_players = newProperty("envoys.ignore-behaviour.not-enough-players", false);
+    public static final Property<Boolean> envoys_ignore_behaviour_no_spawn_locations_found = newProperty("envoys.ignore-behaviour.no-spawn-locations-found", false);
+    public static final Property<Boolean> envoys_ignore_behaviour_started = newProperty("envoys.ignore-behaviour.started", false);
+    public static final Property<Boolean> envoys_ignore_behaviour_envoys_remaining = newProperty("envoys.ignore-behaviour.envoys-remaining", true);
 }

--- a/paper/src/main/java/com/badbones69/crazyenvoys/listeners/EnvoyClickListener.java
+++ b/paper/src/main/java/com/badbones69/crazyenvoys/listeners/EnvoyClickListener.java
@@ -197,13 +197,13 @@ public class EnvoyClickListener implements Listener {
             if (this.config.getProperty(ConfigKeys.envoys_announce_player_pickup)) {
                 placeholder.put("{player}", player.getName());
                 placeholder.put("{amount}", String.valueOf(this.crazyManager.getActiveEnvoys().size()));
-                Messages.envoys_remaining.broadcastMessage(true, placeholder);
+                Messages.envoys_remaining.broadcastMessage(this.config.getProperty(ConfigKeys.envoys_ignore_behaviour_envoys_remaining), placeholder);
             }
         } else {
             EnvoyEndEvent envoyEndEvent = new EnvoyEndEvent(EnvoyEndEvent.EnvoyEndReason.ALL_CRATES_COLLECTED);
             this.plugin.getServer().getPluginManager().callEvent(envoyEndEvent);
             this.crazyManager.endEnvoyEvent();
-            Messages.ended.broadcastMessage(false);
+            Messages.ended.broadcastMessage(this.config.getProperty(ConfigKeys.envoys_ignore_behaviour_ended));
         }
     }
 


### PR DESCRIPTION
This pull requests improves the ignore functionality by adding toggles within the configuration for what messages should be ignored. These are based on the messages that use the broadcastMessage method, the default values represent the old hard-coded values.

Added with this is a simple improvement to the ignore command that adds '/envoy ignore off -s'
Adding the 'off' argument allows external plugins to control the state of ignoring, without messing with API's and such. 
The -s allows to silence the message being sent on toggle.