### PR TITLE
Feat/thank you player

### DIFF
--- a/paper/src/main/java/com/badbones69/crazyenvoys/api/CrazyManager.java
+++ b/paper/src/main/java/com/badbones69/crazyenvoys/api/CrazyManager.java
@@ -686,6 +686,15 @@ public class CrazyManager {
      *
      * @return true if the event started successfully and false if it had an issue.
      */
+    public boolean startEnvoyEvent() {
+        return startEnvoyEvent(null);
+    }
+
+    /**
+     * Starts the envoy event.
+     *
+     * @return true if the event started successfully and false if it had an issue.
+     */
     public boolean startEnvoyEvent(Player starter) {
         // Called before locations are generated due to it setting those locations to air and causing
         // crates to spawn in the ground when not using falling blocks.

--- a/paper/src/main/java/com/badbones69/crazyenvoys/api/CrazyManager.java
+++ b/paper/src/main/java/com/badbones69/crazyenvoys/api/CrazyManager.java
@@ -397,7 +397,7 @@ public class CrazyManager {
 
                         pluginManager.callEvent(event);
 
-                        if (!event.isCancelled()) startEnvoyEvent();
+                        if (!event.isCancelled()) startEnvoyEvent(null);
                     }
                 }
             }
@@ -686,7 +686,7 @@ public class CrazyManager {
      *
      * @return true if the event started successfully and false if it had an issue.
      */
-    public boolean startEnvoyEvent() {
+    public boolean startEnvoyEvent(Player starter) {
         // Called before locations are generated due to it setting those locations to air and causing
         // crates to spawn in the ground when not using falling blocks.
 
@@ -727,7 +727,13 @@ public class CrazyManager {
         int max = dropLocations.size();
         HashMap<String, String> placeholder = new HashMap<>();
         placeholder.put("{amount}", String.valueOf(max));
-        Messages.started.broadcastMessage(this.config.getProperty(ConfigKeys.envoys_ignore_behaviour_started), placeholder);
+
+        if (starter != null) {
+            placeholder.put("{starter}", starter.getName());
+            Messages.started_player.broadcastMessage(this.config.getProperty(ConfigKeys.envoys_ignore_behaviour_started_player), placeholder);
+        } else {
+            Messages.started.broadcastMessage(this.config.getProperty(ConfigKeys.envoys_ignore_behaviour_started), placeholder);
+        }
 
         if (this.config.getProperty(ConfigKeys.envoys_grace_period_toggle)) {
             this.countdownTimer = new CountdownTimer(this.plugin, this.config.getProperty(ConfigKeys.envoys_grace_period_timer));

--- a/paper/src/main/java/com/badbones69/crazyenvoys/api/enums/Messages.java
+++ b/paper/src/main/java/com/badbones69/crazyenvoys/api/enums/Messages.java
@@ -25,6 +25,7 @@ public enum Messages {
     ended(MessageKeys.envoy_ended, true),
     warning(MessageKeys.envoy_warning),
     started(MessageKeys.envoy_started, true),
+    started_player(MessageKeys.envoy_started_player, true),
     on_going(MessageKeys.hologram_on_going),
     not_running(MessageKeys.hologram_not_running),
     reloaded(MessageKeys.envoy_plugin_reloaded),

--- a/paper/src/main/java/com/badbones69/crazyenvoys/commands/EnvoyCommand.java
+++ b/paper/src/main/java/com/badbones69/crazyenvoys/commands/EnvoyCommand.java
@@ -272,15 +272,17 @@ public class EnvoyCommand implements CommandExecutor {
 
                     EnvoyStartEvent event;
 
+                    Player starter = null;
                     if (sender instanceof Player player) {
                         event = new EnvoyStartEvent(EnvoyStartEvent.EnvoyStartReason.FORCED_START_PLAYER, player);
+                        starter = player;
                     } else {
                         event = new EnvoyStartEvent(EnvoyStartEvent.EnvoyStartReason.FORCED_START_CONSOLE);
                     }
 
                     this.pluginManager.callEvent(event);
 
-                    if (!event.isCancelled() && this.crazyManager.startEnvoyEvent()) Messages.force_start.sendMessage(sender);
+                    if (!event.isCancelled() && this.crazyManager.startEnvoyEvent(starter)) Messages.force_start.sendMessage(sender);
 
                     return true;
                 }

--- a/paper/src/main/java/com/badbones69/crazyenvoys/config/types/ConfigKeys.java
+++ b/paper/src/main/java/com/badbones69/crazyenvoys/config/types/ConfigKeys.java
@@ -225,5 +225,6 @@ public class ConfigKeys implements SettingsHolder {
     public static final Property<Boolean> envoys_ignore_behaviour_not_enough_players = newProperty("envoys.ignore-behaviour.not-enough-players", false);
     public static final Property<Boolean> envoys_ignore_behaviour_no_spawn_locations_found = newProperty("envoys.ignore-behaviour.no-spawn-locations-found", false);
     public static final Property<Boolean> envoys_ignore_behaviour_started = newProperty("envoys.ignore-behaviour.started", false);
+    public static final Property<Boolean> envoys_ignore_behaviour_started_player = newProperty("envoys.ignore-behaviour.started-player", false);
     public static final Property<Boolean> envoys_ignore_behaviour_envoys_remaining = newProperty("envoys.ignore-behaviour.envoys-remaining", true);
 }

--- a/paper/src/main/java/com/badbones69/crazyenvoys/config/types/MessageKeys.java
+++ b/paper/src/main/java/com/badbones69/crazyenvoys/config/types/MessageKeys.java
@@ -60,6 +60,10 @@ public class MessageKeys implements SettingsHolder {
             "{prefix}&7An envoy event has just started. &6{amount} &7crates have spawned around spawn for 5m."
     ));
 
+    public static final Property<List<String>> envoy_started_player = newListProperty("envoys.started-player.list", List.of(
+            "{prefix}&7An envoy event has just been started by {starter}. &6{amount} &7crates have spawned around spawn for 5m."
+    ));
+
     public static final Property<List<String>> envoys_remaining = newListProperty("envoys.left", List.of(
             "{prefix}&6{player} &7has just found a tier envoy. There are now &6{amount} &7left to find."
     ));

--- a/paper/src/main/java/com/badbones69/crazyenvoys/listeners/FlareClickListener.java
+++ b/paper/src/main/java/com/badbones69/crazyenvoys/listeners/FlareClickListener.java
@@ -83,7 +83,7 @@ public class FlareClickListener implements Listener {
                 EnvoyStartEvent envoyStartEvent = new EnvoyStartEvent(EnvoyStartEvent.EnvoyStartReason.FLARE);
                 this.plugin.getServer().getPluginManager().callEvent(envoyStartEvent);
 
-                if (!envoyStartEvent.isCancelled() && this.crazyManager.startEnvoyEvent()) {
+                if (!envoyStartEvent.isCancelled() && this.crazyManager.startEnvoyEvent(player)) {
                     Messages.used_flare.sendMessage(player);
 
                     this.flareSettings.takeFlare(player);


### PR DESCRIPTION
This pull requests adds a seperate message when for when a player uses a flare, or an admin uses the start command. 

1. This adds clarity to the end-user why an envoy was suddenly started
2. It allows for thanking the person whom started the envoy.

I added a unused method in case some plugins use the old startEnvoyEvent method.