### PR TITLE
Fix seconds always showing

### DIFF
--- a/paper/src/main/java/com/badbones69/crazyenvoys/Methods.java
+++ b/paper/src/main/java/com/badbones69/crazyenvoys/Methods.java
@@ -186,7 +186,7 @@ public class Methods {
         if (day > 0) message += day + Messages.day.getMessage() + ", ";
         if (day > 0 || hour > 0) message += hour + Messages.hour.getMessage() + ", ";
         if (day > 0 || hour > 0 || minute > 0) message += minute + Messages.minute.getMessage() + ", ";
-        if (day > 0 || hour > 0 || minute > 0 || second > 0) message += second + Messages.second.getMessage() + ", ";
+        if (second > 0) message += second + Messages.second.getMessage() + ", ";
 
         if (message.length() < 2) {
             message = "0" + Messages.second.getMessage();


### PR DESCRIPTION
Removes the logic of always adding the seconds to time-related strings.

I don't know if this is a personal preference thingy, but i feel like messages that contain '5m, 0s' look rather weird. As the 0s does not add any value.